### PR TITLE
[Matrix|N*] some cleanups and improve of track length read

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
   - if [[ $DEBIAN_BUILD != true ]]; then mkdir -p definition/${app_id}; fi
   - if [[ $DEBIAN_BUILD != true ]]; then echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt; fi
   - if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons; fi
-  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-addon-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep $TRAVIS_BUILD_DIR; fi
 
 script: 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This is a [Kodi](https://kodi.tv) audio decoder addon for various game music files.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.org/xbmc/audiodecoder.gme.svg?branch=Matrix)](https://travis-ci.org/xbmc/audiodecoder.gme/branches)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.gme?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=5&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.gme/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.gme/branches/)
 <!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.gme?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-gme?branch=Matrix) -->

--- a/audiodecoder.gme/addon.xml.in
+++ b/audiodecoder.gme/addon.xml.in
@@ -17,7 +17,10 @@
     <summary lang="en_GB">Game Music Emu Audio Decoder</summary>
     <description lang="de_DE">Das GME-Format (Game Music Emu) wird verwendet, um die Audioausgabe verschiedener Videospielkonsolen zu emulieren, die in den 1980er und 1990er Jahren beliebt waren. Es gibt dem Sound ein "Retro" -Gefühl.
 
-Unterstützte Formate:
+[B]Hinweis:[/B]
+Nicht alle Dateiformate geben Länge und wird in diesem Fall auf 2,5 Minuten gesetzt.
+
+[B]Unterstützte Formate:[/B]
 - AY: ZX Spectrum/Amstrad CPC
 - GBS: Nintendo Game Boy
 - GYM: Sega Genesis/Mega Drive
@@ -29,7 +32,10 @@ Unterstützte Formate:
 - VGM/VGZ: Sega Master System/Mark III, Sega Genesis/Mega Drive,BBC Micro</description>
     <description lang="en_GB">Game Music Emu (GME) format is used to emulate the audio output of various video game consoles popular in the 1980s and 1990s. It gives a "retro" feel to the sound.
 
-Supported Formats:
+[B]Note:[/B]
+Not all file formats give length and in this case it is set to 2.5 minutes.
+
+[B]Supported Formats:[/B]
 - AY: ZX Spectrum/Amstrad CPC
 - GBS: Nintendo Game Boy
 - GYM: Sega Genesis/Mega Drive

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: audiodecoder.gme
 Source: https://github.com/xbmc/audiodecoder.gme
 
 Files: *
-Copyright: 2005-2020 Team Kodi
+Copyright: 2005-2021 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/lib/kodi-File_Extractor-note.txt
+++ b/lib/kodi-File_Extractor-note.txt
@@ -1,0 +1,7 @@
+File_Extractor source from https://github.com/kode54/File_Extractor
+Sync to ?
+
+Note: Contains bigger changes to use on Kodi
+
+- https://bitbucket.org/kode54/file_extractor
+- https://git.lopez-snowhill.net/chris/file_extractor

--- a/lib/kodi-Game_Music_Emu-note.txt
+++ b/lib/kodi-Game_Music_Emu-note.txt
@@ -1,4 +1,8 @@
 Game_Music_Emu source from https://github.com/kode54/Game_Music_Emu
-Sync to fd803c8
+Sync to fd803c8 (25 Oct. 2018)
 
 Note: Not included part "VGM info now reads UTF-8 tags" (f811076), in conflict with File_Extractor.
+
+Another source:
+- https://git.lopez-snowhill.net/chris/game_music_emu
+- https://bitbucket.org/kode54/game_music_emu

--- a/src/GMECodec.cpp
+++ b/src/GMECodec.cpp
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2014-2020 Arne Morten Kvarving
- *  Copyright (C) 2016-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2014-2021 Arne Morten Kvarving
+ *  Copyright (C) 2016-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/GMECodec.cpp
+++ b/src/GMECodec.cpp
@@ -81,13 +81,29 @@ int64_t CGMECodec::Seek(int64_t time)
 
 bool CGMECodec::ReadTag(const std::string& filename, kodi::addon::AudioDecoderInfoTag& tag)
 {
+  int track = 0;
+  std::string toLoad(filename);
+  if (toLoad.rfind("stream") != std::string::npos)
+  {
+    size_t iStart = toLoad.rfind('-') + 1;
+    track = atoi(toLoad.substr(iStart, toLoad.size() - iStart - 10).c_str());
+    //  The directory we are in, is the file
+    //  that contains the bitstream to play,
+    //  so extract it
+    size_t slash = toLoad.rfind('\\');
+    if (slash == std::string::npos)
+      slash = toLoad.rfind('/');
+    toLoad = toLoad.substr(0, slash);
+  }
+
   gme_t* gme = nullptr;
-  gme_open_file(filename.c_str(), &gme, 48000);
+  gme_open_file(toLoad.c_str(), &gme, 48000);
   if (!gme)
     return false;
 
   gme_info_t* out;
-  gme_track_info(gme, &out, 0);
+  gme_track_info(gme, &out, track > 0 ? track - 1 : 0);
+  tag.SetTrack(track);
   tag.SetSamplerate(48000);
   tag.SetChannels(2);
   tag.SetDuration(out->play_length / 1000);

--- a/src/GMECodec.h
+++ b/src/GMECodec.h
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2014-2020 Arne Morten Kvarving
- *  Copyright (C) 2016-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2014-2021 Arne Morten Kvarving
+ *  Copyright (C) 2016-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.


### PR DESCRIPTION
About the addon.xml looks now like this:

![Bildschirmfoto vom 2021-04-18 19-29-34](https://user-images.githubusercontent.com/6879739/115154699-7ee11080-a07c-11eb-9723-175ea5752a84.png)

Otherwise it can be confusing for user that much files gives always 2.5 minutes.

Performed compile and run test on Linux with C++14, C++17 and C++20.
Runtime tests was OK.