### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 This is a [Kodi](https://kodi.tv) audio decoder addon for various game music files.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.gme?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=5&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.gme/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.gme/branches/)
-<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.gme?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-gme?branch=Matrix) -->
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.gme?branchName=Nexus)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=5&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.gme/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.gme/branches/)
+<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.gme?branch=Nexus&svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-gme?branch=Nexus) -->
 
 ## Build instructions
 

--- a/audiodecoder.gme/addon.xml.in
+++ b/audiodecoder.gme/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.gme"
-  version="3.0.0"
+  version="20.0.0"
   name="GME Audio Decoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
 trigger:
   branches:
     include:
-    - Matrix
+    - Nexus
     - releases/*
   paths:
     include:


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.